### PR TITLE
remove duplicated label

### DIFF
--- a/charts/cloud-native-postgresql/templates/deployment.yaml
+++ b/charts/cloud-native-postgresql/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: cloud-native-postgresql
         {{- include "cloud-native-postgresql.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
The label is already defined in `cloud-native-postgresql.selectorLabels` in the `_helpers.tpl` file.

Fixes issue https://github.com/EnterpriseDB/cloud-native-postgresql-helm/issues/79