### PR TITLE
chore: fix config.yaml template condition

### DIFF
--- a/charts/edb-postgres-distributed-for-kubernetes/templates/config.yaml
+++ b/charts/edb-postgres-distributed-for-kubernetes/templates/config.yaml
@@ -26,8 +26,7 @@ metadata:
   {{- end }}
 data:
   {{- toYaml .Values.config.data | nindent 2 }}
-{{- end }}
-{{- else -}}
+{{- else }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -41,4 +40,5 @@ metadata:
   {{- end }}
 stringData:
   {{- toYaml .Values.config.data | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/edb-postgres-for-kubernetes/templates/config.yaml
+++ b/charts/edb-postgres-for-kubernetes/templates/config.yaml
@@ -25,15 +25,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- if .Values.config.clusterWide  -}}
+  {{- if .Values.config.clusterWide -}}
   {{- toYaml .Values.config.data | nindent 2 }}
   {{- else -}}
   {{- $watchNamespaceMap := dict "WATCH_NAMESPACE" .Release.Namespace -}}
   {{- $fullConfiguration := merge .Values.config.data $watchNamespaceMap -}}
   {{- toYaml $fullConfiguration | nindent 2 }}
   {{- end -}}
-{{- end }}
-{{- else -}}
+{{- else }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -46,5 +45,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 stringData:
+  {{- if .Values.config.clusterWide -}}
   {{- toYaml .Values.config.data | nindent 2 }}
+  {{- else -}}
+  {{- $watchNamespaceMap := dict "WATCH_NAMESPACE" .Release.Namespace -}}
+  {{- $fullConfiguration := merge .Values.config.data $watchNamespaceMap -}}
+  {{- toYaml $fullConfiguration | nindent 2 }}
+  {{- end -}}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Fix an issue that would wrongly render the template for the Operator configuration `config.yaml`.
Also, make sure the clusterWide/namespacedScope configuration is applied also when creating a `Secret` and not only for `ConfigMap`.