### PR TITLE
feat: use single path for PGD and PGD proxy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ helm upgrade --dependency-update \
   --set image.imageCredentials.username=${USERNAME} \
   --set image.imageCredentials.password=${PASSWORD} \
   --set global.repository=docker.enterprisedb.com/k8s_standard_pgd \
-  edb/edb-postgres-distributed-for-kubernete
+  edb/edb-postgres-distributed-for-kubernetes
 ```
 
 If we want to use different flavor or different version of PGD image, we can set the following two

--- a/README.md
+++ b/README.md
@@ -237,14 +237,16 @@ helm upgrade --dependency-update \
   edb/edb-postgres-distributed-for-kubernetes
 ```
 
-If we want to use different flavor or different version of PGD image, we can set the following two
-global options, for each helm chart release, the PGD and PGD proxy are upgrade to latest well-tested
-versions, by default, the PGD image here is using postgresql-pgd.
+If we want to use a different flavor or a different version of PGD image, we can set the following two
+global options, for each helm chart release: 
 
-- `pgdImageName`: The PGD image name to be used by the operator. PGD image with this name will be
- pulled from `global.repository`.
-- `proxyImageName`: The PGD proxy image name to be used by the operator. PGD proxy image with
-this name will be pulled from `global.repository`.
+- `pgdImageName`: the PGD image name to be used by the operator. PGD image (with this name)
+will be pulled from `global.repository`;
+- `proxyImageName`: the PGD proxy image name to be used by the operator. PGD proxy image (with this name)
+will be pulled from `global.repository`.
+
+PGD and PGD proxy are upgraded to the latest well-tested versions.
+By default, the PGD image here is using postgresql-pgd.
 
 This example uses the `edb-postgres-advanced-pgd` PGD images.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ helm upgrade --install edb-pg4k \
 This will create a deployment in the `postgresql-operator-system` namespace.
 You can check it's ready:
 
-``` sh
+```sh
 $ kubectl get deployments -n postgresql-operator-system
 NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
 edb-pg4k-edb-postgres-for-kubernetes   1/1     1            1           11s
@@ -118,15 +118,16 @@ image registry by default:
 helm upgrade --dependency-update \
   --install edb-pg4k-pgd \
   --namespace pgd-operator-system \
-  --create-namespace edb/edb-postgres-distributed-for-kubernetes \
+  --create-namespace \
   --set image.imageCredentials.username=${USERNAME} \
-  --set image.imageCredentials.password=${PASSWORD}
+  --set image.imageCredentials.password=${PASSWORD} \
+  edb/edb-postgres-distributed-for-kubernetes
 ```
 
 Once the above runs, a new namespace `pgd-operator-system` will be
 created, with several deployments,  including the two operators.
 
-``` sh
+```sh
 $ kubectl get deployments -n pgd-operator-system
 NAME                                                   READY   UP-TO-DATE   AVAILABLE   AGE
 edb-pg4k-pgd-cert-manager                              1/1     1            1           7m46s
@@ -166,9 +167,9 @@ in your K8S setup, you can skip this section and go directly to the setup of [PG
 
 To deploy cert-manager in its own namespace
 
-``` sh
-$ helm repo add jetstack https://charts.jetstack.io
-$ helm upgrade --install cert-manager jetstack/cert-manager \
+```console
+$ helm repo add jetstack https://charts.jetstack.io &&
+  helm upgrade --install cert-manager jetstack/cert-manager \
   --create-namespace \
   --namespace cert-manager \
   --version "v1.16.1" \
@@ -189,18 +190,18 @@ to set `cert-manager.enabled` to false if cert-manager is installed separately.
 to put the focus on the `enabled=false` condition. The flags may still be
 necessary, unless the credentials are provided in the `values.yaml` file.
 
-``` sh
+```console
 helm upgrade --dependency-update \
   --install edb-pg4k-pgd \
   --namespace pgd-operator-system \
   --create-namespace \
-  edb/edb-postgres-distributed-for-kubernetes \
-  --set cert-manager.enabled=false
+  --set cert-manager.enabled=false \
+  edb/edb-postgres-distributed-for-kubernetes
 ```
 
 You should now have a seperate namespace for each operator:
 
-``` sh
+```sh
 $ kubectl get ns
 NAME                         STATUS   AGE
 …
@@ -219,11 +220,8 @@ invocation.
 
 The following example uses the `k8s_standard_pgd` registry in
 `docker.enterprisedb.com`. Following is the description of set options.
-- `global.repository`: The repository where the PG4K-PGD and PG4K operator image are downloaded from.
-This is a global setting, which is shared for both PG4K-PGD and PG4K operators.
-- `PGD_IMAGE_NAME`: The location where the PGD image are pulled from.
-- `PGD_PROXY_IMAGE_NAME`: The location where PGD Proxy image are pulled from, usually
-the same with `PGD_IMAGE_NAME`.
+- `global.repository`: The repository where the operator and operand image are downloaded from.
+This is a global setting, which is shared for both PG4K-PGD and PG4K operators and pgd operands.
 
 Assuming that you have your necessary credentials, please fill in the USERNAME
 and PASSWORD below.
@@ -233,13 +231,35 @@ helm upgrade --dependency-update \
   --install edb-pg4k-pgd \
   --namespace pgd-operator-system \
   --create-namespace \
-  edb/edb-postgres-distributed-for-kubernetes \
   --set image.imageCredentials.username=${USERNAME} \
   --set image.imageCredentials.password=${PASSWORD} \
   --set global.repository=docker.enterprisedb.com/k8s_standard_pgd \
-  --set config.data.PGD_IMAGE_NAME=docker.enterprisedb.com/k8s_standard_pgd/postgresql-pgd:15.6-5.5.1-1 \
-  --set config.data.PGD_PROXY_IMAGE_NAME=docker.enterprisedb.com/k8s_standard_pgd/edb-pgd-proxy:5.5.0
+  edb/edb-postgres-distributed-for-kubernete
 ```
+
+If we want to use different flavor or different version of PGD image, we can set the following two
+global options, for each helm chart release, the PGD and PGD proxy are upgrade to latest well-tested
+versions, by default, the PGD image here is using postgresql-pgd.
+
+- `pgdImageName`: The PGD image name to be used by the operator. PGD image with this name will be
+ pulled from `global.repository`.
+- `proxyImageName`: The PGD proxy image name to be used by the operator. PGD proxy image with
+this name will be pulled from `global.repository`.
+
+This example uses the `edb-postgres-advanced-pgd` PGD images.
+
+```console
+helm upgrade --dependency-update \
+  --install edb-pg4k-pgd \
+  --namespace pgd-operator-system \
+  --create-namespace \
+  --set image.imageCredentials.username=${USERNAME} \
+  --set image.imageCredentials.password=${PASSWORD} \
+  --set global.pgdImageName=edb-postgres-advanced-pgd:16.4.1-5.5.1-1 \
+  --set global.proxyImageName=edb-pgd-proxy:5.5.0 \
+  edb/edb-postgres-distributed-for-kubernetes
+```
+
 
 ## Deployment using local chart
 
@@ -284,14 +304,14 @@ helm upgrade --install edb-pg4k-lts \
 and then deploy the PG4K-PGD chart with `edb-postgres-for-kubernetes-lts.enabled=false`
 set.
 
-```
+```console
 helm upgrade --install edb-pg4k-pgd \
   --namespace pgd-operator-system \
   --create-namespace \
   --set image.imageCredentials.username=${USERNAME} \
   --set image.imageCredentials.password=${PASSWORD} \
-  charts/edb-postgres-distributed-for-kubernetes \
-  --set edb-postgres-for-kubernetes-lts.enabled=false
+  --set edb-postgres-for-kubernetes-lts.enabled=false \
+  charts/edb-postgres-distributed-for-kubernetes
 ```
 
 **Note:** The image locations are elided. Please refer to the sections above

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,6 +86,11 @@ follow these steps:
    1. update PGD_IMAGE_NAME and PGD_PROXY_IMAGE_NAME defaults inside
       `charts/edb-postgres-distributed-for-kubernetes/values.yaml` according to the default
       versions present in the release.
+   1. update the `.appVersion` and `.verions` in subchart
+      `./charts/edb-postgres-distributed-for-kubernetes/charts/edb-postgres-for-kubernetes-lts`,
+      and follow the [EPK Release](#how-to-release-the-edb-postgres-for-kubernetes-chart) to update
+      the subchart to latest PG4K lts release.
+
 
 From here onward, you can follow the steps of the [EPK Release](#how-to-release-the-edb-postgres-for-kubernetes-chart), starting from `point 6`.
 

--- a/charts/edb-postgres-distributed-for-kubernetes/README.md
+++ b/charts/edb-postgres-distributed-for-kubernetes/README.md
@@ -36,8 +36,8 @@ EDB Postgres Distributed for Kubernetes Helm Chart
 | cert-manager.installCRDs | bool | `true` |  |
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources |
 | config.create | bool | `true` | Specifies whether the secret should be created |
-| config.data.PGD_IMAGE_NAME | string | `"docker.enterprisedb.com/k8s_enterprise_pgd/postgresql-pgd:16.4-5.5.1-1"` | Specifies the location of the pgd image to be used for the operator docker.enterprisedb.com/k8s_standard_pgd/postgresql-pgd:16.4-5.5.1-1 |
-| config.data.PGD_PROXY_IMAGE_NAME | string | `"docker.enterprisedb.com/k8s_enterprise_pgd/edb-pgd-proxy:5.5.0"` | Specifies the location of the pgd-proxy image to be used for the operator  docker.enterprisedb.com/k8s_standard_pgd/edb-pgd-proxy:5.5.0 |
+| config.data.PGD_IMAGE_NAME | string | `""` | Specifies the location of the pgd image (include path) to be used for the operator, this will overwrite the global repository/pgdImageName |
+| config.data.PGD_PROXY_IMAGE_NAME | string | `""` | Specifies the location of the pgd image (include path) to be used for the operator, this will overwrite the global repository/pgdImageName|
 | config.data.PULL_SECRET_NAME | string | `"edb-pull-secret"` |  |
 | config.name | string | `"pgd-operator-controller-manager-config"` |  |
 | config.secret | bool | `false` | Specifies whether it should be stored in a secret, instead of a configmap |
@@ -48,7 +48,11 @@ EDB Postgres Distributed for Kubernetes Helm Chart
 | edb-postgres-for-kubernetes-lts.image.repository | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | global | object | `{"repository":"docker.enterprisedb.com/k8s_enterprise_pgd"}` | Global values |
-| global.repository | string | `"docker.enterprisedb.com/k8s_enterprise_pgd"` | Specifies the repository where the operator image to be downloaded from repository: docker.enterprisedb.com/k8s_standard_pgd |
+| global.repository | string | `"docker.enterprisedb.com/k8s_enterprise_pgd"` | Specifies the repository where the operator image to be downloaded from. Another repository is: docker.enterprisedb.com/k8s_standard_pgd |
+| global.pgdImageName | string | `"postgresql-pgd:16.4-5.5.1-1"` | Specifies the name of pgd image to be used for the operator, this image will be downloaded from
+global repository |
+| global.proxyImageName | string | `"edb-pgd-proxy:5.5.0"` | Specifies the name of pgd-proxy image to be used for the operator, this image will be downloaded from
+global repository |
 | image.imageCredentials.create | bool | `true` | Specifies if an imagePullSecret should be created |
 | image.imageCredentials.name | string | `"edb-pull-secret"` |  |
 | image.imageCredentials.password | string | `""` |  |

--- a/charts/edb-postgres-distributed-for-kubernetes/templates/_helpers.tpl
+++ b/charts/edb-postgres-distributed-for-kubernetes/templates/_helpers.tpl
@@ -41,6 +41,23 @@ Create the pg4k-pgd operator image name
 {{- end }}
 {{- end }}
 
+
+{{/*
+Create the pgd and pgd proxy operand image name in configmap
+*/}}
+{{- define "edb-postgres-distributed-for-kubernetes.configData" }}
+{{- if not .Values.config.data.PGD_IMAGE_NAME }}
+{{-  $_ := set .Values.config.data "PGD_IMAGE_NAME" (printf "%s/%s" .Values.global.repository  .Values.global.pgdImageName) }}
+{{- end }}
+{{- if not .Values.config.data.PGD_PROXY_IMAGE_NAME }}
+{{-  $_ := set .Values.config.data "PGD_PROXY_IMAGE_NAME" (printf "%s/%s" .Values.global.repository  .Values.global.proxyImageName) }}
+{{- end }}
+{{- with .Values.config.data }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+
 {{/*
 Common labels
 */}}

--- a/charts/edb-postgres-distributed-for-kubernetes/templates/config.yaml
+++ b/charts/edb-postgres-distributed-for-kubernetes/templates/config.yaml
@@ -25,7 +25,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- toYaml .Values.config.data | nindent 2 }}
+  {{- include "edb-postgres-distributed-for-kubernetes.configData" . | nindent 2 }}
 {{- else }}
 apiVersion: v1
 kind: Secret
@@ -39,6 +39,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 stringData:
-  {{- toYaml .Values.config.data | nindent 2 }}
+  {{- include "edb-postgres-distributed-for-kubernetes.configData" . | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/edb-postgres-distributed-for-kubernetes/values.schema.json
+++ b/charts/edb-postgres-distributed-for-kubernetes/values.schema.json
@@ -118,6 +118,12 @@
             "properties": {
                 "repository": {
                     "type": "string"
+                },
+                "pgdImageName": {
+                    "type": "string"
+                },
+                "proxyImageName": {
+                    "type": "string"
                 }
             }
         },

--- a/charts/edb-postgres-distributed-for-kubernetes/values.yaml
+++ b/charts/edb-postgres-distributed-for-kubernetes/values.yaml
@@ -20,11 +20,19 @@ replicaCount: 1
 
 # -- Global values
 global:
-  # -- Specifies the repository where the operator image to be downloaded from
+  # -- Specifies the repository where the operator and operand image to be downloaded from
   # repository: docker.enterprisedb.com/k8s_standard_pgd
   repository: docker.enterprisedb.com/k8s_enterprise_pgd
+  # -- Specifies the pgd image name to be used for the operator, the image will be downloaded from
+  # global repository
+  pgdImageName: postgresql-pgd:16.4-5.5.1-1
+  # -- Specifies the pgd-proxy image name to be used for the operator, the image will be downloaded from
+  # global repository
+  proxyImageName: edb-pgd-proxy:5.5.0
 
+# -- operator image configuration
 image:
+  # -- Specifies the repository of the pgd operator image, this will overwrite the global repository
   repository: ""
   # -- Specifies the name of the operator image to be pulled from repository
   imageName: pg4k-pgd
@@ -84,15 +92,14 @@ config:
   create: true
   # -- Specifies whether it should be stored in a secret, instead of a configmap
   secret: false
-
   data:
     PULL_SECRET_NAME: edb-pull-secret
-    # -- Specifies the location of the pgd image to be used for the operator
-    # docker.enterprisedb.com/k8s_standard_pgd/postgresql-pgd:16.4-5.5.1-1
-    PGD_IMAGE_NAME: docker.enterprisedb.com/k8s_enterprise_pgd/postgresql-pgd:16.4-5.5.1-1
-    # -- Specifies the location of the pgd-proxy image to be used for the operator
-    #  docker.enterprisedb.com/k8s_standard_pgd/edb-pgd-proxy:5.5.0
-    PGD_PROXY_IMAGE_NAME: docker.enterprisedb.com/k8s_enterprise_pgd/edb-pgd-proxy:5.5.0
+    # -- Specifies the location of the pgd image (include path) to be used for the operator
+    # this will overwrite the global repository/pgdImageName
+    PGD_IMAGE_NAME: ""
+    # -- Specifies the location of the pgd-proxy image (include path) to be used for the operator
+    #  this will overwrite the global repository/proxyImageName
+    PGD_PROXY_IMAGE_NAME: ""
   name: pgd-operator-controller-manager-config
 
 # -- Additional arguments to be added to the operator's args list
@@ -170,6 +177,7 @@ cert-manager:
 edb-postgres-for-kubernetes-lts:
   enabled: true
   image:
+    # -- Specifies the repository of the pg4k operator image, this will overwrite the global repository
     repository: ""
   crds:
     create: true


### PR DESCRIPTION
Introduced in `global.pgdImageName` and `global.proxyImageName` to be used
as operand image name, which will be append to `global.repository` for the operand path.
Now we have a single repository path `global.repository` and each image
(two operators and two operands) has its name and tag.